### PR TITLE
Make the background of the example white

### DIFF
--- a/example.svg
+++ b/example.svg
@@ -13,6 +13,7 @@
    height="91.348839mm"
    viewBox="0 0 68.54793 32.489091"
    id="svg648"
+   style="background-color:white"
    sodipodi:docname="example.svg"
    inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <metadata


### PR DESCRIPTION
With the new [GitHub dark theme](https://github.com/settings/appearance), the sample doesn't look good since the background is transparent but most characters are black:

![Screenshot_2021-01-24 threedaymonk lilypond-shamisen](https://user-images.githubusercontent.com/23304955/105631623-b59af680-5e92-11eb-82e3-bd0287a009ca.png)

This PR makes the background of the sample SVG white:
![Screenshot_2021-01-24 jeandeaual lilypond-shamisen](https://user-images.githubusercontent.com/23304955/105631627-b764ba00-5e92-11eb-8f07-f9e1963267b9.png)

This doesn't change anything for the default theme.